### PR TITLE
Silent build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,12 @@ AC_PROG_CXX
 
 # We're moving to the future, to C++11!
 AC_CONFIG_MACRO_DIR([.])
+
+old_cxxflags=$CXXFLAGS
 AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])
+AM_CXXFLAGS=$CXXFLAGS
+AC_SUBST([AM_CXXFLAGS])
+CXXFLAGS=$old_cxxflags
 
 # Defines
 # TODO: Conditionally set these depending on build system.

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,8 @@ AC_INIT([crimesquad], [4.10.0],[kamaljalals@gmail.com])
 AC_CONFIG_SRCDIR([src/cursesgraphics.cpp])
 AC_CONFIG_HEADER([config.h])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
+AM_SILENT_RULES([yes])
+
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,5 +52,4 @@ crimesquad_SOURCES = game.cpp lcsio.cpp cursesmovie.cpp compat.cpp\
  sdl/SDL_timer.h sdl/SDL_touch.h sdl/SDL_types.h sdl/SDL_version.h\
  sdl/SDL_video.h sdl/begin_code.h sdl/close_code.h
 
-crimesquad_CPPFLAGS = -DINSTALL_DATA_DIR=\"$(datadir)\"
-crimesquad_CXXFLAGS = -I$(top_srcdir)/src
+crimesquad_CPPFLAGS = -DINSTALL_DATA_DIR=\"$(datadir)\" -I$(top_srcdir)/src 

--- a/src/includes.h
+++ b/src/includes.h
@@ -74,7 +74,9 @@
 
 //PACKAGE_VERSION must be defined here or the game won't compile on Windows! Don't remove it!!!
 // -- yetisyny
-#define PACKAGE_VERSION "4.10.1"
+#ifndef HAVE_CONFIG_H
+# define PACKAGE_VERSION "4.10.1"
+#endif
 
 const int version=41010;
 const int lowestloadversion=40100;


### PR DESCRIPTION
Enable silent building when using an autotools build.

The amount of noise coming from an autotools build is so high that it's hard to see warnings and errors.  This PR sets the default to silent builds to help the errors and warning pop.

Noisy builds can be enabled at any time with the <tt>--disable-silent-rules</tt> option passed to **configure** or by using **make V=1**.