### PR TITLE
Cross-compile for Mingw64 from a Linux host.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,7 @@ AM_SILENT_RULES([yes])
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX
+AC_LANG(C++)
 
 # We're moving to the future, to C++11!
 AC_CONFIG_MACRO_DIR([.])
@@ -22,6 +23,25 @@ AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])
 AM_CXXFLAGS=$CXXFLAGS
 AC_SUBST([AM_CXXFLAGS])
 CXXFLAGS=$old_cxxflags
+
+# Checks for typedefs, structures, and compiler characteristics.
+AC_HEADER_STDBOOL
+AC_C_CONST
+AC_C_INLINE
+AC_TYPE_SIZE_T
+AC_HEADER_TIME
+
+# Checks for library functions.
+AC_FUNC_MALLOC
+AC_TYPE_SIGNAL
+AC_FUNC_STAT
+
+
+AC_CHECK_FUNCS([memset mkdir strchr])
+
+AC_CHECK_HEADER([langinfo.h],
+                [AC_DEFINE([HAVE_LANGINFO_H], [1],
+                    [Define is you have <lamginfo.h>.])])
 
 # Defines
 # TODO: Conditionally set these depending on build system.
@@ -85,20 +105,5 @@ if test "$LACK_SDL2" = 1; then
    AC_MSG_WARN([ *** Compiling without SDL2 or SDL2_mixer, and with DONT_INCLUDE_SDL defined.])
 fi
 
-# Checks for typedefs, structures, and compiler characteristics.
-AC_HEADER_STDBOOL
-AC_C_CONST
-AC_C_INLINE
-AC_TYPE_SIZE_T
-AC_HEADER_TIME
-
-# Checks for library functions.
-AC_FUNC_MALLOC
-AC_TYPE_SIGNAL
-AC_FUNC_STAT
-
-
-
-AC_CHECK_FUNCS([memset mkdir strchr])
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,9 @@ AC_TYPE_SIZE_T
 AC_HEADER_TIME
 
 # Checks for library functions.
-AC_FUNC_MALLOC
+#
+# commented out until it's proved a glibc-compatible malloc is needed
+# AC_FUNC_MALLOC
 AC_TYPE_SIGNAL
 AC_FUNC_STAT
 

--- a/src/common.h
+++ b/src/common.h
@@ -32,6 +32,8 @@
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
+#endif
+#ifdef HAVE_LANGINFO_H
 #include <langinfo.h>
 #endif
 

--- a/src/common.h
+++ b/src/common.h
@@ -39,6 +39,10 @@
 
 #ifdef WIN32 // safe to do now that we did that earlier thing defining WIN32 if _WIN32 was defined
    #include <windows.h>
+
+#  ifdef KEY_EVENT
+#   undef KEY_EVENT
+#  endif
    #define GO_PORTABLE
    #include <io.h> //needed for unlink()
    #include <direct.h>

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -185,8 +185,8 @@ unsigned long getSeed()
    fnvHash(_seed,GetCurrentProcessId()); /* process ID for current process */
    SYSTEM_INFO info; /* a whole bunch of system info */
    GetSystemInfo(&info); /* get the system info */
-   fnvHash(_seed,(unsigned long)info.lpMinimumApplicationAddress); /* pointer to minimum accessible memory location */
-   fnvHash(_seed,(unsigned long)info.lpMaximumApplicationAddress); /* pointer to maximum accessible memory location */
+   fnvHash(_seed,(intptr_t)info.lpMinimumApplicationAddress); /* pointer to minimum accessible memory location */
+   fnvHash(_seed,(intptr_t)info.lpMaximumApplicationAddress); /* pointer to maximum accessible memory location */
 #else // we're on a POSIX system and can use POSIX API entropy sources
 #if defined(_SC_AVPHYS_PAGES) && defined(_SC_PAGESIZE) // might or might not be defined... optional in POSIX
    fnvHash(_seed,sysconf(_SC_AVPHYS_PAGES)*sysconf(_SC_PAGESIZE)); /* current available memory */

--- a/src/includes.h
+++ b/src/includes.h
@@ -1004,9 +1004,11 @@ inline int addchar(char ch,Log &log) { log.record(ch); return addchar(ch); }
 inline int mvaddchar(int y,int x,char ch,Log &log) { log.record(ch); return mvaddchar(y,x,ch); }
 /* Redefining addstr() and mvaddstr() so they use addchar() and mvaddchar(), fixing display of extended characters */
 #undef addstr
-inline int addstr(const char* text) { int ret=ERR; for(int i=0;i<len(text);i++) ret=addchar(text[i]); return ret; }
 #undef mvaddstr
+#if NCURSES_VERSION_MAJOR < 6
+inline int addstr(const char* text) { int ret=ERR; for(int i=0;i<len(text);i++) ret=addchar(text[i]); return ret; }
 inline int mvaddstr(int y,int x,const char* text) { int ret=move(y,x); if(ret!=ERR) ret=addstr(text); return ret; }
+#endif
 /* Various wrappers to addstr() and mvaddstr() which handle permutations of:
    - Including or not including the gamelog for external message logging
    - std::string or c-style char arrays */


### PR DESCRIPTION
Fix problems related to cross-building for Windows on a Linux host.  Includes fixes for several issues.

* handle missing POSIX header <langinfo.h>
* remove duplicated KEY_EVENT definition introduced by <windows.h>
* removed AC_FUNC_MALLOC because it's not required and breaks C++ cross-compilation
* fixed the assumption that sizeof(intptr_t) == sizeof(long)
* fixed some ODR violations due to newer ncurses 6.0

Closes issue #2.