### PR TITLE
Add .travis.yml to enable CI at GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
 before_script:
   - mkdir build
   - cd build
-  - ../autogen.sh CXX=$COMPILER --disable-silent-rules
+  - ../bootstrap CXX=$COMPILER --disable-silent-rules
 script:
   - make
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+sudo: false
+dist: trusty
+language: generic
+
+branches:
+  only:
+  - master
+
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env: COMPILER=g++-5
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - g++-5
+            - clang-4.0
+      env: COMPILER=clang++-4.0
+
+before_script:
+  - mkdir build
+  - cd build
+  - ../autogen.sh CXX=$COMPILER --disable-silent-rules
+script:
+  - make
+
+notifications:
+  email:
+    - bregma@users.noreply.github.com

--- a/bootstrap
+++ b/bootstrap
@@ -1,2 +1,20 @@
-#!/bin/sh
-autoreconf -fvi
+#!/bin/sh -e
+#
+# @file bootstrap
+# @brief Script to prepare the project build environment from a SCM checkout.
+#
+# Copyright 2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+#
+blddir=$(pwd)
+srcdir=$(dirname $0)
+if [ -z "$srcdir" ]; then
+  srcdir="$blddir"
+fi
+
+cd "$srcdir"
+autoreconf -i -f -v
+
+cd "$blddir"
+if [ -z "$NOCONFIGURE" ]; then
+  "$srcdir/configure" "$@"
+fi


### PR DESCRIPTION
Add integration with the Travis-CI build service

This PR adds integration with the Travis-CI build service for native Linux CI from GitHub.

Closes #4 